### PR TITLE
Allow setting a custom local auth db

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,21 @@ function invalidateCache(passthrough) {
 }
 
 var api = {};
+api.setSeamlessAuthLocalDB = function (localDB, callback) {
+  local = localDB;
+
+  var promise = Auth.useAsAuthenticationDB.call(local)
+    .then(invalidateCache);
+
+  nodify(promise, callback);
+  return promise;
+};
+
+api.unsetSeamlessAuthLocalDB = function () {
+  local = undefined;
+  invalidateCache();
+};
+
 api.setSeamlessAuthRemoteDB = function (remoteName, remoteOptions, callback) {
   remote = new PouchDB(remoteName, remoteOptions);
 


### PR DESCRIPTION
Instead of relying on a default `_users` PouchDB for local auth, allow
setting a custom one. This can be useful for using together with e.g.
crypto-pouch, for having a per-user encrypted auth db.