### PR TITLE
2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pouchdb-seamless-auth",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index.js",
   "description": "Seamless switching between online (CouchDB) and offline (PouchDB) authentication.",
   "repository": {
@@ -25,7 +25,7 @@
     "pouchdb-promise": "^0.0.0",
     "extend": "^3.0.0",
     "promise-nodify": "^1.0.0",
-    "pouchdb-auth": "^3.0.0"
+    "pouchdb-auth": "^3.0.1"
   },
   "devDependencies": {
     "pouchdb-plugin-helper": "^3.0.0"


### PR DESCRIPTION
- use pouchdb-auth 3.0.1
- compatible with pouchdb 6.x